### PR TITLE
Add README doc tests to unit tests

### DIFF
--- a/tests/test_libyara_wrapper.py
+++ b/tests/test_libyara_wrapper.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import time
+import doctest
 
 import yara
 from yara.libyara_wrapper import *
@@ -15,6 +16,10 @@ class TestLibYara(unittest.TestCase):
         #    filename = "_"
         #print "%s:%s: %s"%(filename, line_number, error_message)
         self.err_callback_count += 1
+
+    def test_readme_doctest(self):
+        """Run doctests on README documentation"""
+        doctest.testfile('../README.rst')
 
     def test_build_context_with_a_rule(self):
         """compile and destroy a good rule"""


### PR DESCRIPTION
Runs doctests on README as part of the unit tests.

This is probably going to break your builds on Travis-CI. Although it would be a good time to go check the pull request testing they added recently.
